### PR TITLE
Add support for node 20 to the handler typing

### DIFF
--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -61,7 +61,7 @@ export interface HandlerDefinition {
 	 *
 	 * Defaults to nodejs14.x if not specified.
 	 */
-	runtime?: 'nodejs14.x' | 'nodejs16.x' | 'nodejs18.x' | 'nodejs20.x';
+	runtime?: 'nodejs14.x' | 'nodejs16.x' | 'nodejs18.x' | 'nodejs20.x' | string;
 	/**
 	 * The AWS Lambda architecture to use for functions.
 	 *

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -61,7 +61,7 @@ export interface HandlerDefinition {
 	 *
 	 * Defaults to nodejs14.x if not specified.
 	 */
-	runtime?: 'nodejs14.x' | 'nodejs16.x' | 'nodejs18.x';
+	runtime?: 'nodejs14.x' | 'nodejs16.x' | 'nodejs18.x' | 'nodejs20.x';
 	/**
 	 * The AWS Lambda architecture to use for functions.
 	 *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tailwind/faceteer-cdk",
-	"version": "5.0.1",
+	"version": "5.1.0",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
We're already using `any` to support node 20 in Ghostwriter v2 and draper, this just makes it official via the types.