### PR TITLE
add runtime management mode

### DIFF
--- a/constructs/base-function.ts
+++ b/constructs/base-function.ts
@@ -86,6 +86,9 @@ export class BaseFunction<
 			vpc: useVpc ? network?.vpc : undefined,
 			vpcSubnets: useVpc ? network?.vpcSubnets : undefined,
 			securityGroups: useVpc ? network?.securityGroups : undefined,
+			runtimeManagementMode: definition.runtimeManagementMode
+				? definition.runtimeManagementMode
+				: defaults?.runtimeManagementMode,
 			runtime: runtime
 				? new Runtime(runtime, RuntimeFamily.NODEJS, {
 						// This is enabled in AWS CDK built-in runtimes:

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -88,6 +88,7 @@ export interface LambdaServiceProps {
 		logRetention?: 'destroy' | 'retain';
 		logRetentionDuration?: LogRetentionDays;
 		runtime?: HandlerDefinition['runtime'];
+		runtimeManagementMode?: lambda.RuntimeManagementMode;
 		architecture?: HandlerDefinition['architecture'];
 	};
 	/** VPC, subnet, and security groups for the lambda functions.

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'aws-lambda';
 import { LogRetentionDays } from '../util/log-retention';
+import type { RuntimeManagementMode } from 'aws-cdk-lib/aws-lambda';
 
 /**
  * The base lambda handler definition for all
@@ -61,7 +62,13 @@ export interface HandlerDefinition {
 	 *
 	 * Defaults to nodejs14.x if not specified.
 	 */
-	runtime?: 'nodejs14.x' | 'nodejs16.x' | 'nodejs18.x' | 'nodejs20.x' | string & {};
+	runtime?:
+		| 'nodejs14.x'
+		| 'nodejs16.x'
+		| 'nodejs18.x'
+		| 'nodejs20.x'
+		| (string & {});
+	runtimeManagementMode?: RuntimeManagementMode;
 	/**
 	 * The AWS Lambda architecture to use for functions.
 	 *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tailwind/faceteer-cdk",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tailwind/faceteer-cdk",
-			"version": "6.0.0",
+			"version": "6.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@aws-sdk/client-sqs": "^3.536.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tailwind/faceteer-cdk",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
Recently in Scooby we had a problem after AWS updated the lambda runtime's node version underneath us that caused a problem opening new tabs in puppeteer.

postmortem incoming, but this allows us to prevent AWS from changing it, or change it manually ourselves as needed.